### PR TITLE
Proposed: tagName prop

### DIFF
--- a/src/components/Column.js
+++ b/src/components/Column.js
@@ -6,7 +6,7 @@ import { divvy, media, passOn } from '../utils';
 
 
 function ColumnContainer(props) {
-  const { children, debug, divisions, fluid, xs, sm, md, lg,
+  const { children, tagName, debug, divisions, fluid, xs, sm, md, lg,
     xsShift, smShift, mdShift, lgShift,
     ...rest } = props;
   const newChildren = passOn(children, [Row], (child) => {
@@ -16,11 +16,12 @@ function ColumnContainer(props) {
         : child.props.debug
     };
   });
-  return <div {...rest}>{newChildren}</div>;
+  return React.createElement(tagName || 'div', rest, newChildren);
 }
 
 ColumnContainer.propTypes = {
   children: React.PropTypes.node,
+  tagName: React.PropTypes.string,
   className: React.PropTypes.string,
   debug: React.PropTypes.bool,
   divisions: React.PropTypes.number,

--- a/src/components/Page.js
+++ b/src/components/Page.js
@@ -5,7 +5,7 @@ import { passOn } from '../utils';
 
 
 function PageContainer(props) {
-  const { children, debug, ...rest } = props;
+  const { children, tagName, debug, ...rest } = props;
   const newChildren = passOn(children, [Row], (child) => {
     return {
       debug: typeof child.props.debug === 'undefined'
@@ -13,11 +13,12 @@ function PageContainer(props) {
         : child.props.debug
     };
   });
-  return <div {...rest}>{newChildren}</div>;
+  return React.createElement(tagName || 'div', rest, newChildren);
 }
 
 PageContainer.propTypes = {
   children: React.PropTypes.node,
+  tagName: React.PropTypes.string,
   className: React.PropTypes.string,
   debug: React.PropTypes.bool
 };

--- a/src/components/Row.js
+++ b/src/components/Row.js
@@ -6,7 +6,7 @@ import { divvy, passOn } from '../utils';
 
 
 function RowContainer(props) {
-  const { children, debug, divisions, ...rest } = props;
+  const { children, tagName, debug, divisions, ...rest } = props;
   const newChildren = passOn(children, [Column], (child) => {
     return {
       debug: typeof child.props.debug === 'undefined'
@@ -15,11 +15,12 @@ function RowContainer(props) {
       divisions
     };
   });
-  return <section {...rest}>{newChildren}</section>;
+  return React.createElement(tagName || 'section', rest, newChildren);
 }
 
 RowContainer.propTypes = {
   children: React.PropTypes.node,
+  tagName: React.PropTypes.string,
   className: React.PropTypes.string,
   debug: React.PropTypes.bool,
   divisions: React.PropTypes.number


### PR DESCRIPTION
Great project, very useful and nice use of styled-components. One thing I was thinking about is having the ability to use various HTML5 sectioning elements (section, aside, article, header, footer, nav, etc). This PR adds a new prop that allows you to specify a tagName to correspond to a section, e.g.:

```
<Page tagName='article'>
  <Row>
    <Column tagName='header' sm={8} smShift={2}>
        <h1>This is a column that's centered using the shift props</h1>
    </Column>
  </Row>
  <Row>
    <Column tagName='aside' fluid sm={4}>
        <h3>Sidebar</h3>
    </Column>
    <Column fluid sm={8}>
      <p>Main body</p>
    </Column>
</Page>
```

Any thoughts?