### PR TITLE
Fix for plain text descendant bug

### DIFF
--- a/src/utils/passOn.js
+++ b/src/utils/passOn.js
@@ -8,11 +8,11 @@ import React from 'react';
 // to a component type that exists in the ofTypes array.
 export default function(children, ofTypes, process = r => r) {
   const response = React.Children.map(children,
-    child => React.cloneElement(child,
-      // Check to see if the child's component type is whitelisted,
-      // and then process it.
-      ofTypes.includes(child.type) ? process(child) : { }
-    )
+    // Check to see if the child's component type is whitelisted,
+    // and then process it.
+    child => React.isValidElement(child) && ofTypes.includes(child.type)
+      ? React.cloneElement(child, process(child))
+      : child
   );
   return response;
 }


### PR DESCRIPTION
I saw the outstanding bug here https://github.com/JSBros/hedron/issues/28 and attempted to fix it.

It looks like children can be of the following types `null | string | React.createClass() | React.createElement()` so I added an additional check using React.isValidElement which should pass the child through if it's not an instance of a component or element that the passOn callback expects.