### PR TITLE
feat: add Hidden component

### DIFF
--- a/src/components/Hidden.js
+++ b/src/components/Hidden.js
@@ -1,0 +1,59 @@
+// @flow
+/* eslint-disable no-unused-vars */
+import React from 'react';
+import styled from 'styled-components';
+import Row from './Row';
+import Column from './Column';
+import { divvy, media, passOn } from '../utils';
+
+type Props = {
+  children?: Array<React.Element<>>,
+  debug?: boolean,
+  xs?: boolean,
+  sm?: boolean,
+  md?: boolean,
+  lg?: boolean
+}
+
+function HiddenContainer(props: Props) {
+  const { children, debug, xs, sm, md, lg, ...rest } = props;
+  const newChildren = passOn(children, [Row, Column], (child) => {
+    return {
+      debug: typeof child.props.debug === 'undefined'
+        ? debug
+        : child.props.debug,
+    };
+  });
+  return <div {...rest}>{ newChildren }</div>;
+}
+
+const Hidden = styled(HiddenContainer)`
+  ${props =>
+    props.xs
+      ? 'display: none;'
+      : 'display: inherit;'
+  }
+  ${media.sm`
+    ${props =>
+      props.sm
+        ? 'display: none;'
+        : 'display: inherit;'
+    }
+  `}
+  ${media.md`
+    ${props =>
+      props.md
+        ? 'display: none;'
+        : 'display: inherit;'
+    }
+  `}
+  ${media.lg`
+    ${props =>
+      props.lg
+        ? 'display: none;'
+        : 'display: inherit;'
+    }
+  `}
+`;
+
+export default Hidden;

--- a/src/components/Page.js
+++ b/src/components/Page.js
@@ -3,6 +3,7 @@
 import React from 'react';
 import styled from 'styled-components';
 import Row from './Row';
+import Hidden from './Hidden';
 import { passOn } from '../utils';
 
 type Props = {
@@ -16,7 +17,7 @@ type Props = {
 
 function PageContainer(props: Props) {
   const { children, tagName, debug, fluid, ...rest } = props;
-  const newChildren = passOn(children, [Row], (child) => {
+  const newChildren = passOn(children, [Row, Hidden], (child) => {
     return {
       debug: typeof child.props.debug === 'undefined'
         ? debug

--- a/src/components/Row.js
+++ b/src/components/Row.js
@@ -3,6 +3,7 @@
 import React from 'react';
 import styled from 'styled-components';
 import Column from './Column';
+import Hidden from './Hidden';
 import { divvy, passOn } from '../utils';
 
 type Props = {
@@ -24,7 +25,7 @@ function RowContainer(props: Props) {
   const { children, tagName, debug, divisions,
     alignContent, alignItems, alignSelf, justifyContent, order,
     ...rest } = props;
-  const newChildren = passOn(children, [Column], (child) => {
+  const newChildren = passOn(children, [Column, Hidden], (child) => {
     return {
       debug: typeof child.props.debug === 'undefined'
         ? debug

--- a/src/index.js
+++ b/src/index.js
@@ -2,6 +2,7 @@
 import Column from './components/Column';
 import Row from './components/Row';
 import Page from './components/Page';
+import Hidden from './components/Hidden';
 import { divvy, media, passOn } from './utils';
 
 const utils = {
@@ -10,4 +11,4 @@ const utils = {
   passOn,
 };
 
-export { Column, Page, Row, utils };
+export { Column, Page, Row, Hidden, utils };

--- a/stories/index.js
+++ b/stories/index.js
@@ -1,6 +1,6 @@
 import React from 'react';
 import { storiesOf } from '@kadira/storybook';
-import { Page, Row, Column } from '../src';
+import { Page, Row, Column, Hidden } from '../src';
 
 storiesOf('Layouts', module)
   .add('Column Sizes (xs)', () => (
@@ -157,5 +157,39 @@ storiesOf('Layouts', module)
       <Row><Column lgShift={9} /></Row>
       <Row><Column lgShift={10} /></Row>
       <Row><Column lgShift={11} /></Row>
+    </Page>
+  ));
+
+storiesOf('Hidden', module)
+  .add('xs', () => (
+    <Page debug>
+      <p>
+        This row is hidden on xs
+      </p>
+      <Hidden xs><Row><Column /></Row></Hidden>
+    </Page>
+  ))
+  .add('sm', () => (
+    <Page debug>
+      <p>
+        This row is hidden on sm
+      </p>
+      <Hidden sm><Row><Column /></Row></Hidden>
+    </Page>
+  ))
+  .add('md', () => (
+    <Page debug>
+      <p>
+        This row is hidden on md
+      </p>
+      <Hidden md><Row><Column /></Row></Hidden>
+    </Page>
+  ))
+  .add('lg', () => (
+    <Page debug>
+      <p>
+        This row is hidden on lg
+      </p>
+      <Hidden lg><Row><Column /></Row></Hidden>
     </Page>
   ));


### PR DESCRIPTION
Implements the `Hidden` component described in #29

## Usage

```jsx
<Page debug>
  <p>
    This row is hidden on xs
  </p>
  <Hidden xs><Row><Column /></Row></Hidden>

  <p>
    This row is hidden on sm
  </p>
  <Hidden sm><Row><Column /></Row></Hidden>

  <p>
    This row is hidden on md
  </p>
  <Hidden md><Row><Column /></Row></Hidden>

  <p>
    This row is hidden on lg
  </p>
  <Hidden lg><Row><Column /></Row></Hidden>
</Page>
```

You can also combine sizes for more precise control

```jsx
<Page debug>
  <p>
    This row is only visible on md resolution (between 768px and 1100px)
  </p>
  <Hidden xs sm lg><Row><Column /></Row></Hidden>
</Page>
```