### PR TITLE
Add a way to customize breakpoints using a provider

### DIFF
--- a/src/components/BreakpointProvider.js
+++ b/src/components/BreakpointProvider.js
@@ -1,4 +1,3 @@
-// @flow
 import React, { Component, PropTypes, Children } from 'react';
 
 const breakpointsShape = PropTypes.shape({
@@ -28,14 +27,16 @@ export default class BreakpointProvider extends Component {
   }
 }
 
-export const withBreakpoints = (WrappedComponent) => class Breakpoints extends Component {
-  static contextTypes = {
-    breakpoints: breakpointsShape,
-  };
+export const withBreakpoints = WrappedComponent =>
+  // eslint-disable-next-line react/no-multi-comp
+  class Breakpoints extends Component { // eslint-disable-line  react/prefer-stateless-function
+    static contextTypes = {
+      breakpoints: breakpointsShape,
+    };
 
-  render() {
-    const { breakpoints } = this.context;
+    render() {
+      const { breakpoints } = this.context;
 
-    return <WrappedComponent {...this.props} breakpoints={breakpoints} />;
+      return <WrappedComponent {...this.props} breakpoints={breakpoints} />;
+    }
   };
-};

--- a/src/components/BreakpointProvider.js
+++ b/src/components/BreakpointProvider.js
@@ -1,0 +1,41 @@
+// @flow
+import React, { Component, PropTypes, Children } from 'react';
+
+const breakpointsShape = PropTypes.shape({
+  sm: PropTypes.number,
+  md: PropTypes.number,
+  lg: PropTypes.number,
+});
+
+export default class BreakpointProvider extends Component {
+  static propTypes = {
+    children: PropTypes.node,
+    breakpoints: breakpointsShape,
+  };
+
+  static childContextTypes = {
+    breakpoints: breakpointsShape,
+  };
+
+  getChildContext() {
+    const { breakpoints } = this.props;
+
+    return { breakpoints };
+  }
+
+  render() {
+    return Children.only(this.props.children);
+  }
+}
+
+export const withBreakpoints = (WrappedComponent) => class Breakpoints extends Component {
+  static contextTypes = {
+    breakpoints: breakpointsShape,
+  };
+
+  render() {
+    const { breakpoints } = this.context;
+
+    return <WrappedComponent {...this.props} breakpoints={breakpoints} />;
+  };
+};

--- a/src/components/BreakpointProvider.js
+++ b/src/components/BreakpointProvider.js
@@ -1,4 +1,3 @@
-// @flow
 import React, { Component, PropTypes, Children } from 'react';
 
 const breakpointsShape = PropTypes.shape({

--- a/src/components/Column.js
+++ b/src/components/Column.js
@@ -3,6 +3,7 @@
 import React from 'react';
 import styled from 'styled-components';
 import Row from './Row';
+import { withBreakpoints } from './BreakpointProvider';
 import { divvy, media, passOn } from '../utils';
 
 type Props = {
@@ -20,12 +21,13 @@ type Props = {
   xsShift?: number,
   smShift?: number,
   mdShift?: number,
-  lgShift?: number
+  lgShift?: number,
+  breakpoints?: Object,
 }
 
 function ColumnContainer(props: Props) {
   const { children, tagName, debug, divisions, fluid, xs, sm, md, lg, theme,
-    xsShift, smShift, mdShift, lgShift,
+    xsShift, smShift, mdShift, lgShift, breakpoints,
     ...rest } = props;
   const newChildren = passOn(children, [Row], (child) => {
     return {
@@ -60,7 +62,7 @@ const Column = styled(ColumnContainer)`
       ? `margin-left: ${divvy(props.divisions, props.xsShift)}%;`
       : null
   }
-  ${media.sm`
+  ${({ breakpoints }) => media.sm(breakpoints)`
     ${props =>
       props.sm
         ? `width: ${divvy(props.divisions, props.sm)}%;`
@@ -71,7 +73,7 @@ const Column = styled(ColumnContainer)`
         : null
     }
   `}
-  ${media.md`
+  ${({ breakpoints }) => media.md(breakpoints)`
     ${props =>
       props.md
         ? `width: ${divvy(props.divisions, props.md)}%;`
@@ -83,7 +85,7 @@ const Column = styled(ColumnContainer)`
         : null
     }
   `}
-  ${media.lg`
+  ${({ breakpoints }) => media.lg(breakpoints)`
     ${props =>
       props.lg
         ? `width: ${divvy(props.divisions, props.lg)}%;`
@@ -97,4 +99,4 @@ const Column = styled(ColumnContainer)`
   `}
 `;
 
-export default Column;
+export default withBreakpoints(Column);

--- a/src/components/Hidden.js
+++ b/src/components/Hidden.js
@@ -4,6 +4,7 @@ import React from 'react';
 import styled from 'styled-components';
 import Row from './Row';
 import Column from './Column';
+import { withBreakpoints } from './BreakpointProvider';
 import { divvy, media, passOn } from '../utils';
 
 type Props = {
@@ -12,11 +13,12 @@ type Props = {
   xs?: boolean,
   sm?: boolean,
   md?: boolean,
-  lg?: boolean
+  lg?: boolean,
+  breakpoints?: Object,
 }
 
 function HiddenContainer(props: Props) {
-  const { children, debug, xs, sm, md, lg, ...rest } = props;
+  const { children, debug, xs, sm, md, lg, breakpoints, ...rest } = props;
   const newChildren = passOn(children, [Row, Column], (child) => {
     return {
       debug: typeof child.props.debug === 'undefined'
@@ -33,21 +35,21 @@ const Hidden = styled(HiddenContainer)`
       ? 'display: none;'
       : 'display: inherit;'
   }
-  ${media.sm`
+  ${({ breakpoints }) => media.sm(breakpoints)`
     ${props =>
       props.sm
         ? 'display: none;'
         : 'display: inherit;'
     }
   `}
-  ${media.md`
+  ${({ breakpoints }) => media.md(breakpoints)`
     ${props =>
       props.md
         ? 'display: none;'
         : 'display: inherit;'
     }
   `}
-  ${media.lg`
+  ${({ breakpoints }) => media.lg(breakpoints)`
     ${props =>
       props.lg
         ? 'display: none;'
@@ -56,4 +58,4 @@ const Hidden = styled(HiddenContainer)`
   `}
 `;
 
-export default Hidden;
+export default withBreakpoints(Hidden);

--- a/src/index.js
+++ b/src/index.js
@@ -3,7 +3,9 @@ import Column from './components/Column';
 import Row from './components/Row';
 import Page from './components/Page';
 import Hidden from './components/Hidden';
-import BreakpointProvider, { withBreakpoints } from './components/BreakpointProvider';
+import BreakpointProvider, {
+  withBreakpoints,
+} from './components/BreakpointProvider';
 import { divvy, media, passOn } from './utils';
 
 const utils = {
@@ -12,4 +14,7 @@ const utils = {
   passOn,
 };
 
-export { Column, Page, Row, Hidden, BreakpointProvider, withBreakpoints, utils };
+export {
+  Column, Page, Row, Hidden,
+  BreakpointProvider, withBreakpoints, utils,
+};

--- a/src/index.js
+++ b/src/index.js
@@ -3,6 +3,7 @@ import Column from './components/Column';
 import Row from './components/Row';
 import Page from './components/Page';
 import Hidden from './components/Hidden';
+import BreakpointProvider, { withBreakpoints } from './components/BreakpointProvider';
 import { divvy, media, passOn } from './utils';
 
 const utils = {
@@ -11,4 +12,4 @@ const utils = {
   passOn,
 };
 
-export { Column, Page, Row, Hidden, utils };
+export { Column, Page, Row, Hidden, BreakpointProvider, withBreakpoints, utils };

--- a/src/utils/media.js
+++ b/src/utils/media.js
@@ -14,6 +14,6 @@ const query = (size, breakpoints = sizes) => (...args) => css`
 
 export default Object.keys(sizes).reduce((acc, label) => {
   const accumulator = acc;
-  accumulator[label] = (breakpoints) => query(label, breakpoints);
+  accumulator[label] = breakpoints => query(label, breakpoints);
   return accumulator;
 }, {});

--- a/src/utils/media.js
+++ b/src/utils/media.js
@@ -7,12 +7,13 @@ const sizes = {
   lg: 1100,
 };
 
+const query = (size, breakpoints = sizes) => (...args) => css`
+  @media (min-width: ${breakpoints[size] || sizes[size]}px) {
+    ${css(...args)}
+  }`;
+
 export default Object.keys(sizes).reduce((acc, label) => {
   const accumulator = acc;
-  accumulator[label] = (...args) => css`
-    @media (min-width: ${sizes[label]}px) {
-      ${css(...args)}
-    }
-  `;
+  accumulator[label] = (breakpoints) => query(label, breakpoints);
   return accumulator;
 }, {});


### PR DESCRIPTION
Breakpoints are now stocked in the context via a provider
```jsx
<BreakpointProvider breakpoints={{ sm: 500, md: 768, lg: 1100 }}>
  <App />
</BreakpointProvider>
```
A Higher Order Component inject the breakpoints in the props of the desired component
```jsx
export default withBreakpoints(Column)
```
And the component can access breakpoints via its props
```jsx
function Column(props) {
  const { breakpoints: { sm, md, lg } } = props;
  // ...
}
```