### PR TITLE
Make BreakpointProvider aware of the previous breakpoints context

### DIFF
--- a/src/components/BreakpointProvider.js
+++ b/src/components/BreakpointProvider.js
@@ -1,4 +1,5 @@
 import React, { Component, PropTypes, Children } from 'react';
+import { defaultBreakpoints } from '../utils';
 
 const breakpointsShape = PropTypes.shape({
   sm: PropTypes.number,
@@ -12,14 +13,23 @@ export default class BreakpointProvider extends Component {
     breakpoints: breakpointsShape,
   };
 
+  static contextTypes = {
+    breakpoints: breakpointsShape,
+  };
+
   static childContextTypes = {
     breakpoints: breakpointsShape,
   };
 
   getChildContext() {
-    const { breakpoints } = this.props;
+    const { breakpoints: propsBreakpoints = {} } = this.props;
+    const { breakpoints: contextBreakpoints = {} } = this.context;
 
-    return { breakpoints };
+    return {
+      breakpoints: {
+        ...defaultBreakpoints, ...contextBreakpoints, ...propsBreakpoints,
+      },
+    };
   }
 
   render() {

--- a/src/index.js
+++ b/src/index.js
@@ -6,11 +6,12 @@ import Hidden from './components/Hidden';
 import BreakpointProvider, {
   withBreakpoints,
 } from './components/BreakpointProvider';
-import { divvy, media, passOn } from './utils';
+import { divvy, media, defaultBreakpoints, passOn } from './utils';
 
 const utils = {
   divvy,
   media,
+  defaultBreakpoints,
   passOn,
 };
 

--- a/src/utils/index.js
+++ b/src/utils/index.js
@@ -1,6 +1,6 @@
 // @flow
 import divvy from './divvy';
-import media from './media';
+import media, { defaultBreakpoints } from './media';
 import passOn from './passOn';
 
-export { divvy, media, passOn };
+export { divvy, media, defaultBreakpoints, passOn };

--- a/src/utils/media.js
+++ b/src/utils/media.js
@@ -1,18 +1,18 @@
 // @flow
 import { css } from 'styled-components';
 
-const sizes = {
+export const defaultBreakpoints = {
   sm: 500,
   md: 768,
   lg: 1100,
 };
 
-const query = (size, breakpoints = sizes) => (...args) => css`
-  @media (min-width: ${breakpoints[size] || sizes[size]}px) {
+const query = (size, breakpoints = defaultBreakpoints) => (...args) => css`
+  @media (min-width: ${breakpoints[size] || defaultBreakpoints[size]}px) {
     ${css(...args)}
   }`;
 
-export default Object.keys(sizes).reduce((acc, label) => {
+export default Object.keys(defaultBreakpoints).reduce((acc, label) => {
   const accumulator = acc;
   accumulator[label] = breakpoints => query(label, breakpoints);
   return accumulator;


### PR DESCRIPTION
BreakpointProvider is now more intelligent and can check the context for existing breakpoints so you can override a single breakpoint further down the tree.