### PR TITLE
use outline instead of border in debug mode

### DIFF
--- a/src/components/Column.js
+++ b/src/components/Column.js
@@ -54,7 +54,7 @@ const Column = styled(ColumnContainer)`
   display: block;
   ${props => props.debug
     ? `background-color: rgba(50, 50, 255, .1);
-       border: 1px solid #fff;`
+       outline: 1px solid #fff;`
     : ''
   }
   box-sizing: border-box;


### PR DESCRIPTION
In `debug` mode, hedron adds a `1px` white border to all `Column` components. This causes layouts to be rendered inconsistently because of the `1px` increase in dimensions. Using the [`outline`](http://www.w3schools.com/css/css_outline.asp) css property prevents this from happening by drawing a line around an element without affecting the element's dimensions.