### PR TITLE
Update babel-plugin-flow-react-proptypes to also use the new prop-types package

### DIFF
--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
     "babel-plugin-add-module-exports": "^0.2.1",
     "babel-plugin-array-includes": "^2.0.3",
     "babel-plugin-external-helpers": "^6.18.0",
-    "babel-plugin-flow-react-proptypes": "^0.18.2",
+    "babel-plugin-flow-react-proptypes": "^3.2.0",
     "babel-preset-es2015": "^6.18.0",
     "babel-preset-es2015-rollup": "^3.0.0",
     "babel-preset-latest": "^6.16.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -582,9 +582,9 @@ babel-plugin-external-helpers@^6.18.0:
   dependencies:
     babel-runtime "^6.0.0"
 
-babel-plugin-flow-react-proptypes@^0.18.2:
-  version "0.18.2"
-  resolved "https://registry.yarnpkg.com/babel-plugin-flow-react-proptypes/-/babel-plugin-flow-react-proptypes-0.18.2.tgz#697e9a16f25b2c1ec3f19c30383f0d46d43b0b9d"
+babel-plugin-flow-react-proptypes@^3.2.0:
+  version "3.2.0"
+  resolved "https://registry.yarnpkg.com/babel-plugin-flow-react-proptypes/-/babel-plugin-flow-react-proptypes-3.2.0.tgz#9e2dcb4f00875159105d3985b2309515da560310"
   dependencies:
     babel-core "^6.18.0"
     babel-template "^6.16.0"


### PR DESCRIPTION
The old plugin was using `React.PropTypes` and triggering the deprecation warning in React 15.5+. 