### PR TITLE
Activating Open Collective

### DIFF
--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -1,0 +1,2 @@
+<!-- Love hedron? Please consider supporting our collective:
+👉  https://opencollective.com/hedron/donate -->

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ $$ |  $$ |$$   ____|$$ |  $$ |$$ |      $$ |  $$ |$$ |  $$ |
 $$ |  $$ |\$$$$$$$\ \$$$$$$$ |$$ |      \$$$$$$  |$$ |  $$ |
 \__|  \__| \_______| \_______|\__|       \______/ \__|  \__|                                                                                                                                
 ```
-[![Travis](https://img.shields.io/travis/JSBros/hedron.svg?style=flat-square)](https://travis-ci.org/JSBros/hedron) [![npm](https://img.shields.io/npm/dt/hedron.svg?style=flat-square)](https://www.npmjs.com/package/hedron) [![David](https://img.shields.io/david/jsbros/hedron.svg?style=flat-square)](https://github.com/JSBros/hedron/issues) [![Slack Status](https://slackin-xtuseyimsc.now.sh/badge.svg)](https://slackin-xtuseyimsc.now.sh/)
+[![Backers on Open Collective](https://opencollective.com/hedron/backers/badge.svg)](#backers) [![Sponsors on Open Collective](https://opencollective.com/hedron/sponsors/badge.svg)](#sponsors) [![Travis](https://img.shields.io/travis/JSBros/hedron.svg?style=flat-square)](https://travis-ci.org/JSBros/hedron) [![npm](https://img.shields.io/npm/dt/hedron.svg?style=flat-square)](https://www.npmjs.com/package/hedron) [![David](https://img.shields.io/david/jsbros/hedron.svg?style=flat-square)](https://github.com/JSBros/hedron/issues) [![Slack Status](https://slackin-xtuseyimsc.now.sh/badge.svg)](https://slackin-xtuseyimsc.now.sh/)
 
 [View a landing page built with Hedron](https://jsbros.github.io/uigradients/).
 
@@ -116,6 +116,60 @@ Contributions of any kind are welcome!
 
 ## Sponsors
 [![sponsored by timber](https://res.cloudinary.com/timber/image/upload/v1490556810/pricing/sponsorship.png)](http://timber.io/?utm_source=github&utm_medium=docs&utm_campaign=hedron)
+
+
+## Backers
+
+Support us with a monthly donation and help us continue our activities. [[Become a backer](https://opencollective.com/hedron#backer)]
+
+<a href="https://opencollective.com/hedron/backer/0/website" target="_blank"><img src="https://opencollective.com/hedron/backer/0/avatar.svg"></a>
+<a href="https://opencollective.com/hedron/backer/1/website" target="_blank"><img src="https://opencollective.com/hedron/backer/1/avatar.svg"></a>
+<a href="https://opencollective.com/hedron/backer/2/website" target="_blank"><img src="https://opencollective.com/hedron/backer/2/avatar.svg"></a>
+<a href="https://opencollective.com/hedron/backer/3/website" target="_blank"><img src="https://opencollective.com/hedron/backer/3/avatar.svg"></a>
+<a href="https://opencollective.com/hedron/backer/4/website" target="_blank"><img src="https://opencollective.com/hedron/backer/4/avatar.svg"></a>
+<a href="https://opencollective.com/hedron/backer/5/website" target="_blank"><img src="https://opencollective.com/hedron/backer/5/avatar.svg"></a>
+<a href="https://opencollective.com/hedron/backer/6/website" target="_blank"><img src="https://opencollective.com/hedron/backer/6/avatar.svg"></a>
+<a href="https://opencollective.com/hedron/backer/7/website" target="_blank"><img src="https://opencollective.com/hedron/backer/7/avatar.svg"></a>
+<a href="https://opencollective.com/hedron/backer/8/website" target="_blank"><img src="https://opencollective.com/hedron/backer/8/avatar.svg"></a>
+<a href="https://opencollective.com/hedron/backer/9/website" target="_blank"><img src="https://opencollective.com/hedron/backer/9/avatar.svg"></a>
+<a href="https://opencollective.com/hedron/backer/10/website" target="_blank"><img src="https://opencollective.com/hedron/backer/10/avatar.svg"></a>
+<a href="https://opencollective.com/hedron/backer/11/website" target="_blank"><img src="https://opencollective.com/hedron/backer/11/avatar.svg"></a>
+<a href="https://opencollective.com/hedron/backer/12/website" target="_blank"><img src="https://opencollective.com/hedron/backer/12/avatar.svg"></a>
+<a href="https://opencollective.com/hedron/backer/13/website" target="_blank"><img src="https://opencollective.com/hedron/backer/13/avatar.svg"></a>
+<a href="https://opencollective.com/hedron/backer/14/website" target="_blank"><img src="https://opencollective.com/hedron/backer/14/avatar.svg"></a>
+<a href="https://opencollective.com/hedron/backer/15/website" target="_blank"><img src="https://opencollective.com/hedron/backer/15/avatar.svg"></a>
+<a href="https://opencollective.com/hedron/backer/16/website" target="_blank"><img src="https://opencollective.com/hedron/backer/16/avatar.svg"></a>
+<a href="https://opencollective.com/hedron/backer/17/website" target="_blank"><img src="https://opencollective.com/hedron/backer/17/avatar.svg"></a>
+<a href="https://opencollective.com/hedron/backer/18/website" target="_blank"><img src="https://opencollective.com/hedron/backer/18/avatar.svg"></a>
+<a href="https://opencollective.com/hedron/backer/19/website" target="_blank"><img src="https://opencollective.com/hedron/backer/19/avatar.svg"></a>
+<a href="https://opencollective.com/hedron/backer/20/website" target="_blank"><img src="https://opencollective.com/hedron/backer/20/avatar.svg"></a>
+<a href="https://opencollective.com/hedron/backer/21/website" target="_blank"><img src="https://opencollective.com/hedron/backer/21/avatar.svg"></a>
+<a href="https://opencollective.com/hedron/backer/22/website" target="_blank"><img src="https://opencollective.com/hedron/backer/22/avatar.svg"></a>
+<a href="https://opencollective.com/hedron/backer/23/website" target="_blank"><img src="https://opencollective.com/hedron/backer/23/avatar.svg"></a>
+<a href="https://opencollective.com/hedron/backer/24/website" target="_blank"><img src="https://opencollective.com/hedron/backer/24/avatar.svg"></a>
+<a href="https://opencollective.com/hedron/backer/25/website" target="_blank"><img src="https://opencollective.com/hedron/backer/25/avatar.svg"></a>
+<a href="https://opencollective.com/hedron/backer/26/website" target="_blank"><img src="https://opencollective.com/hedron/backer/26/avatar.svg"></a>
+<a href="https://opencollective.com/hedron/backer/27/website" target="_blank"><img src="https://opencollective.com/hedron/backer/27/avatar.svg"></a>
+<a href="https://opencollective.com/hedron/backer/28/website" target="_blank"><img src="https://opencollective.com/hedron/backer/28/avatar.svg"></a>
+<a href="https://opencollective.com/hedron/backer/29/website" target="_blank"><img src="https://opencollective.com/hedron/backer/29/avatar.svg"></a>
+
+
+## Sponsors
+
+Become a sponsor and get your logo on our README on Github with a link to your site. [[Become a sponsor](https://opencollective.com/hedron#sponsor)]
+
+<a href="https://opencollective.com/hedron/sponsor/0/website" target="_blank"><img src="https://opencollective.com/hedron/sponsor/0/avatar.svg"></a>
+<a href="https://opencollective.com/hedron/sponsor/1/website" target="_blank"><img src="https://opencollective.com/hedron/sponsor/1/avatar.svg"></a>
+<a href="https://opencollective.com/hedron/sponsor/2/website" target="_blank"><img src="https://opencollective.com/hedron/sponsor/2/avatar.svg"></a>
+<a href="https://opencollective.com/hedron/sponsor/3/website" target="_blank"><img src="https://opencollective.com/hedron/sponsor/3/avatar.svg"></a>
+<a href="https://opencollective.com/hedron/sponsor/4/website" target="_blank"><img src="https://opencollective.com/hedron/sponsor/4/avatar.svg"></a>
+<a href="https://opencollective.com/hedron/sponsor/5/website" target="_blank"><img src="https://opencollective.com/hedron/sponsor/5/avatar.svg"></a>
+<a href="https://opencollective.com/hedron/sponsor/6/website" target="_blank"><img src="https://opencollective.com/hedron/sponsor/6/avatar.svg"></a>
+<a href="https://opencollective.com/hedron/sponsor/7/website" target="_blank"><img src="https://opencollective.com/hedron/sponsor/7/avatar.svg"></a>
+<a href="https://opencollective.com/hedron/sponsor/8/website" target="_blank"><img src="https://opencollective.com/hedron/sponsor/8/avatar.svg"></a>
+<a href="https://opencollective.com/hedron/sponsor/9/website" target="_blank"><img src="https://opencollective.com/hedron/sponsor/9/avatar.svg"></a>
+
+
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -114,9 +114,6 @@ Thanks goes to these wonderful people ([emoji key](https://github.com/kentcdodds
 This project follows the [all-contributors](https://github.com/kentcdodds/all-contributors) specification.
 Contributions of any kind are welcome!
 
-## Sponsors
-[![sponsored by timber](https://res.cloudinary.com/timber/image/upload/v1490556810/pricing/sponsorship.png)](http://timber.io/?utm_source=github&utm_medium=docs&utm_campaign=hedron)
-
 
 ## Backers
 
@@ -158,6 +155,7 @@ Support us with a monthly donation and help us continue our activities. [[Become
 
 Become a sponsor and get your logo on our README on Github with a link to your site. [[Become a sponsor](https://opencollective.com/hedron#sponsor)]
 
+[![sponsored by timber](https://res.cloudinary.com/timber/image/upload/v1490556810/pricing/sponsorship.png)](http://timber.io/?utm_source=github&utm_medium=docs&utm_campaign=hedron)
 <a href="https://opencollective.com/hedron/sponsor/0/website" target="_blank"><img src="https://opencollective.com/hedron/sponsor/0/avatar.svg"></a>
 <a href="https://opencollective.com/hedron/sponsor/1/website" target="_blank"><img src="https://opencollective.com/hedron/sponsor/1/avatar.svg"></a>
 <a href="https://opencollective.com/hedron/sponsor/2/website" target="_blank"><img src="https://opencollective.com/hedron/sponsor/2/avatar.svg"></a>

--- a/package.json
+++ b/package.json
@@ -19,7 +19,8 @@
     "pretest": "npm run lint && npm run flow",
     "test": "jest",
     "storybook": "start-storybook -p 6006",
-    "build-storybook": "build-storybook"
+    "build-storybook": "build-storybook",
+    "postinstall": "opencollective postinstall"
   },
   "bugs": {
     "url": "https://github.com/garetmckinley/hedron/issues"
@@ -68,6 +69,7 @@
     "styled-components": "1.1.3"
   },
   "dependencies": {
+    "opencollective": "^1.0.3",
     "prop-types": "^15.5.8"
   },
   "peerDependencies": {
@@ -78,5 +80,10 @@
     "testPathDirs": [
       "src"
     ]
+  },
+  "collective": {
+    "type": "opencollective",
+    "url": "https://opencollective.com/hedron",
+    "logo": "https://opencollective.com/opencollective/logo.txt"
   }
 }


### PR DESCRIPTION
This pull request adds backers and sponsors from your Open Collective https://opencollective.com/hedron ❤️
  
  It adds two badges at the top to show the latest number of backers and sponsors. It also adds placeholders so that the avatar/logo of new backers/sponsors can automatically be shown without having to update your README.md. [[more info](https://github.com/opencollective/opencollective/wiki/Github-banner)]. See how it looks on [this repo](https://github.com/apex/apex#backers).
  
  You can also add a "Donate" button to your website and automatically show your backers and sponsors there with our widgets. Have a look here: https://opencollective.com/widgets
  
We have also added a `postinstall` script to let people know after `npm|yarn install` that you are welcoming donations. [[More info](https://github.com/OpenCollective/opencollective-cli)]