### PR TITLE
fix: import PropTypes from new prop-types package

### DIFF
--- a/package.json
+++ b/package.json
@@ -74,6 +74,7 @@
   },
   "peerDependencies": {
     "react": "^15.0.0",
+    "prop-types": "^15.6.0",
     "styled-components": "^1.0.10 || ^2.0.0"
   },
   "jest": {

--- a/src/components/LayoutProvider.js
+++ b/src/components/LayoutProvider.js
@@ -1,6 +1,7 @@
 // @flow
 /* globals ReactClass */
-import React, { Component, PropTypes, Children } from "react";
+import React, { Component, Children } from "react";
+import PropTypes from 'prop-types';
 import { defaultBreakpoints } from "../utils";
 
 const defaultDebug = {


### PR DESCRIPTION
import PropTypes from new prop-types package to fix error in react v16