### PR TITLE
doc: remove broken link

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 $$\   $$\                 $$\                               
 $$ |  $$ |                $$ |                              
 $$ |  $$ | $$$$$$\   $$$$$$$ | $$$$$$\   $$$$$$\  $$$$$$$\  
-$$$$$$$$ |$$  __$$\ $$  __$$ |$$  __$$\ $$  __$$\ $$  __$$\ 
+$$$$$$$$ |$$  __$$\ $$  __$$ |$$  __$$\ $$  __$$\ $$  __$$\
 $$  __$$ |$$$$$$$$ |$$ /  $$ |$$ |  \__|$$ /  $$ |$$ |  $$ |
 $$ |  $$ |$$   ____|$$ |  $$ |$$ |      $$ |  $$ |$$ |  $$ |
 $$ |  $$ |\$$$$$$$\ \$$$$$$$ |$$ |      \$$$$$$  |$$ |  $$ |
@@ -25,8 +25,6 @@ or better yet
 #### [View the Documentation →](https://github.com/JSBros/hedron/wiki/Grid-System)
 
 ## Example Usage
-
-[View interactive example on webpackbin](http://www.webpackbin.com/V1zqQ_gZf)
 
 ``` jsx
 import React, { Component } from 'react';
@@ -172,4 +170,3 @@ Become a sponsor and get your logo on our README on Github with a link to your s
 ## License
 
 Hedron is under the [MIT](LICENSE) License.
-


### PR DESCRIPTION
Fixes https://github.com/JSBros/hedron/issues/94
Removed link entirely because WebPackBin has been [deprecated].(https://github.com/cerebral/webpackbin#webpackbin-has-been-deprecated)
![screen shot 2018-07-01 at 4 10 51 pm](https://user-images.githubusercontent.com/12278390/42138387-cb32d98a-7d4a-11e8-8a95-538f509e36e5.png)
